### PR TITLE
BTUC-18602: Update submenu menu items

### DIFF
--- a/src/plugins/platforms/cocoa/qcocoamenu.mm
+++ b/src/plugins/platforms/cocoa/qcocoamenu.mm
@@ -474,9 +474,11 @@ void QCocoaMenu::syncMenuItem_helper(QPlatformMenuItem *menuItem, bool menubarUp
     // synced item, but only on the condition we're all currently hooked to the
     // menunbar. A good indicator of this being the right moment is knowing that
     // we got called from QCocoaMenuBar::updateMenuBarImmediately().
-    if (menubarUpdate)
+    if (menubarUpdate || (cocoaItem->isVisible() && cocoaItem->menu()))
+    {
         if (QCocoaMenu *submenu = cocoaItem->menu())
             submenu->setAttachedItem(syncedItem);
+    }
 }
 
 void QCocoaMenu::syncSeparatorsCollapsible(bool enable)

--- a/src/plugins/platforms/cocoa/qcocoamenuitem.h
+++ b/src/plugins/platforms/cocoa/qcocoamenuitem.h
@@ -110,6 +110,7 @@ public:
     inline bool isMerged() const { return m_merged; }
     inline bool isEnabled() const { return m_enabled && m_parentEnabled; }
     inline bool isSeparator() const { return m_isSeparator; }
+    inline bool isVisible() const { return m_isVisible; }
 
     QCocoaMenu *menu() const { return m_menu; }
     MenuRole effectiveRole() const;


### PR DESCRIPTION
- Submenu items are updated when menu items are added
  and removed by calling updateMenuBarImmediately()
  but not when items are made visible.

Change-Id: If5e48fd9900ef97cf5724c45d5e9a751d1c03140